### PR TITLE
Stay on Ubuntu 12.04 on Travis for now, Ubuntu 14.04 broke link testing over SSL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
 - 2.2.5
+dist: precise
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer


### PR DESCRIPTION
Will check look at this sometime later and go back to 14.04, but the tests started to fail when Travis switched to 14.04 by default. Probably some CA certificate which needs to be added or some missing lib.