### PR TITLE
Workaround to fix issue with bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "html-proofer"
-gem "github-pages", group: :jekyll_plugins
+gem "github-pages", '>=161', group: :jekyll_plugins
 
 group :jekyll_plugins do
   gem "jekyll-paginate"


### PR DESCRIPTION
Bundler was installing an old version of the github-pages package with a too old version of Jekyll causing the tests
to fail.