### PR TITLE
Bump front page stats

### DIFF
--- a/_data/front_stats.yml
+++ b/_data/front_stats.yml
@@ -1,4 +1,4 @@
-stars: 622
-contributors: 62
-num_drivers: 10
+stars: 1538
+contributors: 99
+num_drivers: 38
 ideas: 618


### PR DESCRIPTION
Thought it'd be a good idea to bump these stats, many things changed
over the last 3 years. Included the number of drivers from
``napalm-automation-community`` under the ``num_drivers``.